### PR TITLE
fix bug in tests, expected "TRUE" to equal " true " #staff

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
         <div class="section question-container center-align">
         </div>
         <div class="section center-align true-false-list">
-          <div class="btn center-align hide  green lighten-2"> True </div>
-          <div class="btn center-align hide red lighten-2"> False </div>
+          <div class="btn center-align hide  green lighten-2">True</div>
+          <div class="btn center-align hide red lighten-2">False</div>
         </div>
         <div class="section">
           <div class="center-align">

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -65,8 +65,8 @@ describe('index', () => {
   describe('trueAndFalseButtons', function(){
     it('selects and returns the true and false buttons in the index.html file', function(){
       expect(trueAndFalseButtons().length).to.eq(2)
-      expect(trueAndFalseButtons()[0].innerText).to.eq("TRUE")
-      expect(trueAndFalseButtons()[1].innerText).to.eq("FALSE")
+      expect(trueAndFalseButtons()[0].innerText.toLowerCase()).to.eq("true");
+      expect(trueAndFalseButtons()[1].innerText.toLowerCase()).to.eq("false");
     })
   })
   describe('toggleTrueAndFalseButtons', function(){


### PR DESCRIPTION
Little bug in the test, it compared the *visual* value rendered in the dom rather than the *actual* value in the HTML. (there were random spaces in the HTML, and the CSS converted it into CAPITALS).

Some students got really angry..... said they wasted half a day trying to make the test pass... But luckily it's an easy fix. 

Slightly overengineered  with the `toLowerCase` but thought better safe than sorry.